### PR TITLE
Feature/jsr 310 reflection support

### DIFF
--- a/src/main/java/com/docutools/jocument/annotations/Format.java
+++ b/src/main/java/com/docutools/jocument/annotations/Format.java
@@ -3,6 +3,22 @@ package com.docutools.jocument.annotations;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+/**
+ * Can be applied to JSR-310 / java.time types that implement {@link java.time.temporal.Temporal} on field level, to
+ * enforce a desired String representation in the {@link com.docutools.jocument.Document}.
+ *
+ * <code>
+ * \@Format(value="dd.MM.yyyy", locale = "en-US", zone = "UTC")
+ * private LocalDateTime time;
+ * </code>
+ *
+ * @author codecitizen
+ * @since 28.02.2020
+ * @see java.time.temporal.Temporal
+ * @see java.time.LocalDateTime
+ * @see java.time.LocalDate
+ * @see java.time.ZonedDateTime
+ */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Format {
   String value();

--- a/src/main/java/com/docutools/jocument/annotations/Format.java
+++ b/src/main/java/com/docutools/jocument/annotations/Format.java
@@ -1,0 +1,11 @@
+package com.docutools.jocument.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Format {
+  String value();
+  String zone() default "UTC";
+  String locale() default "en/US";
+}

--- a/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
+++ b/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
@@ -2,15 +2,18 @@ package com.docutools.jocument.impl;
 
 import com.docutools.jocument.PlaceholderData;
 import com.docutools.jocument.PlaceholderResolver;
+import com.docutools.jocument.annotations.Format;
 import com.docutools.jocument.annotations.Image;
 import com.docutools.jocument.impl.word.placeholders.ImagePlaceholderData;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
-import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.Temporal;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.beanutils.BeanUtilsBean;
@@ -51,15 +54,18 @@ public class ReflectionResolver implements PlaceholderResolver {
       }
       if (type.isPrimitive() || type.equals(String.class) || type.isEnum()) {
         return Optional.of(new ScalarPlaceholderData(bub.getProperty(bean, placeholderName)));
-      } else if (LocalDate.class.isAssignableFrom(type)) {
-        LocalDate date = (LocalDate) pub.getProperty(bean, placeholderName);
-        return Optional.of(new ScalarPlaceholderData(date.format(DateTimeFormatter.ISO_DATE)));
       } else if (Collection.class.isAssignableFrom(type)) {
         Collection<Object> property = (Collection<Object>) pub.getProperty(bean, placeholderName);
         List<PlaceholderResolver> list = property.stream()
                 .map(ReflectionResolver::new)
                 .collect(Collectors.toList());
         return Optional.of(new IterablePlaceholderData(list, list.size()));
+      } else if (ReflectionUtils.isJsr310Type(type) && isFieldAnnotatedWith(bean.getClass(), placeholderName, Format.class)) {
+        var value = (Temporal) pub.getProperty(bean, placeholderName);
+        return ReflectionUtils.findFieldAnnotation(bean.getClass(), placeholderName, Format.class)
+                .map(ReflectionResolver::toDateTimeFormatter)
+                .map(formatter -> formatter.format(value))
+                .map(ScalarPlaceholderData::new);
       } else if (Path.class.isAssignableFrom(type) && isFieldAnnotatedWith(bean.getClass(), placeholderName, Image.class)) {
         return Optional.of(new ImagePlaceholderData((Path) pub.getProperty(bean, placeholderName)));
       } else {
@@ -69,5 +75,16 @@ public class ReflectionResolver implements PlaceholderResolver {
     } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
       throw new IllegalStateException("Could not resolve placeholderName against type.", e);
     }
+  }
+
+  private static DateTimeFormatter toDateTimeFormatter(Format format) {
+    var formatter = DateTimeFormatter.ofPattern(format.value());
+    if (!format.zone().isBlank()) {
+      formatter = formatter.withZone(ZoneId.of(format.zone()));
+    }
+    if (!format.locale().isBlank()) {
+      formatter = formatter.withLocale(Locale.forLanguageTag(format.locale()));
+    }
+    return formatter;
   }
 }

--- a/src/main/java/com/docutools/jocument/impl/ReflectionUtils.java
+++ b/src/main/java/com/docutools/jocument/impl/ReflectionUtils.java
@@ -1,0 +1,33 @@
+package com.docutools.jocument.impl;
+
+import java.lang.annotation.Annotation;
+import java.time.temporal.Temporal;
+import java.util.Optional;
+
+public class ReflectionUtils {
+
+  public static boolean isJsr310Type(Class<?> type) {
+    return Temporal.class.isAssignableFrom(type);
+  }
+
+  /**
+   * Gets the annotation instance on the given field in the base class.
+   *
+   * @param baseClass the base class
+   * @param fieldName the field name
+   * @param annotationType the type of the annotation
+   * @param <A> the type of the annotation
+   * @return the annotated instance on the field
+   */
+  public static <A extends Annotation> Optional<A> findFieldAnnotation(Class<?> baseClass, String fieldName, Class<A> annotationType) {
+    try {
+      return Optional.ofNullable(baseClass.getDeclaredField(fieldName)
+              .getDeclaredAnnotation(annotationType));
+    } catch (NoSuchFieldException e) {
+      return Optional.empty();
+    }
+  }
+
+  private ReflectionUtils() {
+  }
+}

--- a/src/test/java/com/docutools/jocument/FormattingJsr310Values.java
+++ b/src/test/java/com/docutools/jocument/FormattingJsr310Values.java
@@ -1,0 +1,110 @@
+package com.docutools.jocument;
+
+import com.docutools.jocument.annotations.Format;
+import com.docutools.jocument.impl.ReflectionResolver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+@DisplayName("Formatting JSR-310 Values")
+class FormattingJsr310Values {
+
+  @Test
+  @DisplayName("Format LocalDate")
+  void shouldFormatLocalDate() {
+    // Arrange
+    var object = new Jsr310Wrappers();
+    object.date = LocalDate.of(2020, 1, 1);
+    var resolver = new ReflectionResolver(object);
+
+    // Act
+    String actual = resolver.resolve("date")
+            .map(PlaceholderData::toString)
+            .orElse("");
+
+    // Assert
+    assertThat(actual, equalTo("1. Jan, 2020"));
+  }
+
+  @Test
+  @DisplayName("Format LocalDateTime")
+  void shouldFormatLocalDateTime() {
+    // Arrange
+    var object = new Jsr310Wrappers();
+    object.dateTime = LocalDateTime.of(2020, 1, 1, 12, 30, 45);
+    var resolver = new ReflectionResolver(object);
+    // Act
+    String actual = resolver.resolve("dateTime")
+            .map(PlaceholderData::toString)
+            .orElse("");
+    // Assert
+    assertThat(actual, equalTo("20/1/1 12:30:45"));
+  }
+
+  @Test
+  @DisplayName("Format Instant")
+  void shouldFormatInstant() {
+    // Arrange
+    var object = new Jsr310Wrappers();
+    object.instant = LocalDateTime.of(2020, 1, 1, 12, 30, 45).toInstant(ZoneOffset.UTC);
+    var resolver = new ReflectionResolver(object);
+    // Act
+    String actual = resolver.resolve("instant")
+            .map(PlaceholderData::toString)
+            .orElse("");
+    // Assert
+    assertThat(actual, equalTo("12:30:45.000"));
+  }
+
+  @Test
+  @DisplayName("Format ZonedDateTime with Locale")
+  void shouldFormatZonedDateTimeWithLocale() {
+    // Arrange
+    var object = new Jsr310Wrappers();
+    object.zonedDateTime = ZonedDateTime.of(2020, 1, 1, 12, 30, 45,  0, ZoneId.of("Europe/Vienna"));
+    var resolver = new ReflectionResolver(object);
+    // Act
+    String actual = resolver.resolve("zonedDateTime")
+            .map(PlaceholderData::toString)
+            .orElse("");
+    // Assert
+    assertThat(actual, equalTo("Jänner 20"));
+  }
+
+  public static class Jsr310Wrappers {
+    @Format("d. MMM, yyyy")
+    private LocalDate date;
+    @Format("yy/M/d h:m:s")
+    private LocalDateTime dateTime;
+    @Format("H:m:s.SSS")
+    private Instant instant;
+    @Format(value = "MMMM yy", locale = "de-AT")
+    private ZonedDateTime zonedDateTime;
+
+    public LocalDate getDate() {
+      return date;
+    }
+
+    public LocalDateTime getDateTime() {
+      return dateTime;
+    }
+
+    public Instant getInstant() {
+      return instant;
+    }
+
+    public ZonedDateTime getZonedDateTime() {
+      return zonedDateTime;
+    }
+  }
+
+}

--- a/src/test/java/com/docutools/jocument/ReflectionUtilityTests.java
+++ b/src/test/java/com/docutools/jocument/ReflectionUtilityTests.java
@@ -1,0 +1,71 @@
+package com.docutools.jocument;
+
+import com.docutools.jocument.impl.ReflectionUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.zip.Adler32;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+@DisplayName("Reflection Utilities")
+public class ReflectionUtilityTests {
+
+  @ParameterizedTest(name = "Detect JSR 310 Types")
+  @ValueSource(classes = {ZonedDateTime.class, LocalDateTime.class, LocalDate.class, Instant.class})
+  void shouldDetectJSR310Types(Class<?> jsr310Type) {
+    // Act
+    boolean jsr310 = ReflectionUtils.isJsr310Type(jsr310Type);
+    // Assert
+    assertThat(jsr310, is(true));
+  }
+
+  @ParameterizedTest(name = "Negatively detect non-JSR 310 Types")
+  @ValueSource(classes = {Duration.class, Object.class, Adler32.class, String.class})
+  void shouldNegativelyDetectNonJsr310Types(Class<?> jsr310Type) {
+    // Act
+    boolean jsr310 = ReflectionUtils.isJsr310Type(jsr310Type);
+    // Assert
+    assertThat(jsr310, is(false));
+  }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface TheAnnotation {}
+
+  static class Clazz {
+    @TheAnnotation
+    private Object field;
+  }
+
+  @Test
+  void shouldGetAnnotationFromPrivateField() {
+    // Arrange
+    var clazz = Clazz.class;
+    // Act
+    Optional<TheAnnotation> annotation = ReflectionUtils.findFieldAnnotation(clazz, "field", TheAnnotation.class);
+    // Assert
+    assertThat(annotation, notNullValue());
+    assertThat(annotation.isPresent(), is(true));
+  }
+
+  @Test
+  void shouldGetEmptyResultWhenAnnotationNotOnField() {
+    // Act
+    var result = ReflectionUtils.findFieldAnnotation(Clazz.class, "field", Override.class);
+    // Assert
+    assertThat(result, notNullValue());
+    assertThat(result.isEmpty(), is(true));
+  }
+
+}


### PR DESCRIPTION
The `java.time` package introduced with Java 8 added some new types
to represent date and time values (LocalDate, ZonedDateTime, ...).

Add new Field Annotation @Format which allows you to specify a format
pattern, locale and time zone to automatically format such values to
the desired String representation in ReflectionResolver.