### PR TITLE
Add Locale to Templates

### DIFF
--- a/src/main/java/com/docutools/jocument/Template.java
+++ b/src/main/java/com/docutools/jocument/Template.java
@@ -3,6 +3,7 @@ package com.docutools.jocument;
 import com.docutools.jocument.impl.TemplateImpl;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -26,10 +27,22 @@ public interface Template {
    * @throws java.lang.IllegalArgumentException when the files MIME type is not supported.
    */
   static Optional<Template> fromClassPath(String path) {
+    return fromClassPath(path, Locale.getDefault());
+  }
+
+  /**
+   * Creates a {@link com.docutools.jocument.Template} instance from a template file on the classpath.
+   *
+   * @param path the resource path
+   * @param locale the templates {@link java.util.Locale}
+   * @return the {@link com.docutools.jocument.Template} when the resource was found.
+   * @throws java.lang.IllegalArgumentException when the files MIME type is not supported.
+   */
+  static Optional<Template> fromClassPath(String path, Locale locale) {
     var mimeType = MimeType.fromFileExtension(path)
             .orElseThrow(() -> new IllegalArgumentException("Unsupported MIME-Type: " + path));
     return Optional.ofNullable(Template.class.getResource(path))
-            .map(url -> new TemplateImpl(url, mimeType));
+            .map(url -> new TemplateImpl(url, mimeType, locale));
   }
 
   /**
@@ -38,6 +51,13 @@ public interface Template {
    * @return {@link java.awt.image.MemoryImageSource}
    */
   MimeType getMimeType();
+
+  /**
+   * Gets the {@link java.util.Locale} setting of the template.
+   *
+   * @return the {@link java.util.Locale}
+   */
+  Locale getLocale();
 
   /**
    * Starts the generation of a document for the given {@link com.docutools.jocument.PlaceholderResolver} asynchronously.

--- a/src/main/java/com/docutools/jocument/impl/TemplateImpl.java
+++ b/src/main/java/com/docutools/jocument/impl/TemplateImpl.java
@@ -8,20 +8,28 @@ import com.docutools.jocument.impl.word.WordDocumentImpl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Locale;
 
 public class TemplateImpl implements Template {
 
   private final URL url;
   private final MimeType mimeType;
+  private final Locale locale;
 
-  public TemplateImpl(URL url, MimeType mimeType) {
+  public TemplateImpl(URL url, MimeType mimeType, Locale locale) {
     this.url = url;
     this.mimeType = mimeType;
+    this.locale = locale;
   }
 
   @Override
   public MimeType getMimeType() {
     return mimeType;
+  }
+
+  @Override
+  public Locale getLocale() {
+    return locale;
   }
 
   @Override

--- a/src/test/java/com/docutools/jocument/WordDocuments.java
+++ b/src/test/java/com/docutools/jocument/WordDocuments.java
@@ -7,8 +7,10 @@ import org.junit.jupiter.api.Test;
 
 import java.awt.*;
 import java.io.IOException;
+import java.util.Locale;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 @DisplayName("Generating Word Documents")
@@ -33,6 +35,17 @@ public class WordDocuments {
 
     // Assert
     assertThat(result.isEmpty(), is(true));
+  }
+
+  @Test
+  @DisplayName("Template should assume systems default Locale, if none is passed with resource.")
+  void shouldAssumeDefaultLocale() {
+    // Act
+    var result = Template.fromClassPath("/templates/word/UserProfileTemplate.docx")
+            .orElseThrow();
+
+    // Assert
+    assertThat(result.getLocale(), equalTo(Locale.getDefault()));
   }
 
   @Test


### PR DESCRIPTION
A templates is bound to a specific language or localisation setting
for things like date or number representaiton.

Adds the attribute locale to the Template so it can be passed down
to resolvers.