### PR TITLE
Implement `@Numeric` annotation

### DIFF
--- a/src/main/java/com/docutools/jocument/PlaceholderResolver.java
+++ b/src/main/java/com/docutools/jocument/PlaceholderResolver.java
@@ -1,5 +1,6 @@
 package com.docutools.jocument;
 
+import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -19,6 +20,17 @@ public interface PlaceholderResolver {
    * @param placeholderName the name of the paceholder
    * @return if the name could've been resolved the {@link com.docutools.jocument.PlaceholderData}
    */
-  Optional<PlaceholderData> resolve(String placeholderName);
+  default Optional<PlaceholderData> resolve(String placeholderName) {
+    return resolve(placeholderName, Locale.getDefault());
+  }
+
+  /**
+   * Resolves the given placeholder name String to a localised {@link com.docutools.jocument.PlaceholderData}.
+   *
+   * @param placeholderName the name of the placeholder
+   * @param locale the localisation settings
+   * @return if the name could've been resolved the localised {@link com.docutools.jocument.PlaceholderData}
+   */
+  Optional<PlaceholderData> resolve(String placeholderName, Locale locale);
 
 }

--- a/src/main/java/com/docutools/jocument/annotations/Money.java
+++ b/src/main/java/com/docutools/jocument/annotations/Money.java
@@ -1,0 +1,9 @@
+package com.docutools.jocument.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Money {
+  String currencyCode() default "";
+}

--- a/src/main/java/com/docutools/jocument/annotations/Numeric.java
+++ b/src/main/java/com/docutools/jocument/annotations/Numeric.java
@@ -1,0 +1,34 @@
+package com.docutools.jocument.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.math.RoundingMode;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Numeric {
+  /**
+   * Sets the maximum number of digits allowed in the fraction portion of a number. maximumFractionDigits must
+   * be >= minimumFractionDigits. If the new value for maximumFractionDigits is less than the current value of
+   * minimumFractionDigits, then minimumFractionDigits will also be set to the new value.
+   *
+   * @return the maximum fraction digits
+   * @see java.text.NumberFormat#setMaximumFractionDigits(int)
+   */
+  int maxFractionDigits() default -1;
+
+  /**
+   * Sets the minimum number of digits allowed in the fraction portion of a number. minimumFractionDigits must
+   * be <= maximumFractionDigits. If the new value for minimumFractionDigits exceeds the current value of
+   * maximumFractionDigits, then maximumIntegerDigits will also be set to the new value
+   *
+   * @return the minimum fraction digits
+   * @see java.text.NumberFormat#setMinimumFractionDigits(int)
+   */
+  int minFractionDigits() default -1;
+  int maxIntDigits() default -1;
+  int minIntDigits() default -1;
+  String currencyCode() default "";
+  boolean groupingUsed() default false;
+  boolean parseIntegerOnly() default false;
+  RoundingMode roundingMode() default RoundingMode.HALF_UP; // TODO what is the default value for RoundingMode?
+}

--- a/src/main/java/com/docutools/jocument/annotations/Numeric.java
+++ b/src/main/java/com/docutools/jocument/annotations/Numeric.java
@@ -3,13 +3,14 @@ package com.docutools.jocument.annotations;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.math.RoundingMode;
+import java.util.Currency;
 
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Numeric {
   /**
-   * Sets the maximum number of digits allowed in the fraction portion of a number. maximumFractionDigits must
-   * be >= minimumFractionDigits. If the new value for maximumFractionDigits is less than the current value of
-   * minimumFractionDigits, then minimumFractionDigits will also be set to the new value.
+   * Sets the maximum number of digits allowed in the fraction portion of a number. maxFractionDigits must
+   * be >= minFractionDigits. If the new value for maxFractionDigits is less than the current value of
+   * minFractionDigits, then minFractionDigits will also be set to the new value.
    *
    * @return the maximum fraction digits
    * @see java.text.NumberFormat#setMaximumFractionDigits(int)
@@ -17,18 +18,66 @@ public @interface Numeric {
   int maxFractionDigits() default -1;
 
   /**
-   * Sets the minimum number of digits allowed in the fraction portion of a number. minimumFractionDigits must
-   * be <= maximumFractionDigits. If the new value for minimumFractionDigits exceeds the current value of
-   * maximumFractionDigits, then maximumIntegerDigits will also be set to the new value
+   * Sets the minimum number of digits allowed in the fraction portion of a number. minFractionDigits must
+   * be <= maxFractionDigits. If the new value for minFractionDigits exceeds the current value of
+   * maxFractionDigits, then maxFractionDigits will also be set to the new value
    *
    * @return the minimum fraction digits
    * @see java.text.NumberFormat#setMinimumFractionDigits(int)
    */
   int minFractionDigits() default -1;
+
+  /**
+   * Sets the maximum number of digits allowed in the integer portion of a number. maxIntDigits must
+   * be >= minIntDigits. If the new value for maxIntDigits is less than the current value of
+   * minIntDigits, then minIntDigits will also be set to the new value.
+   *
+   * @return the maximum integer digits
+   * @see java.text.NumberFormat#setMaximumIntegerDigits(int)
+   */
   int maxIntDigits() default -1;
+
+  /**
+   * Sets the minimum number of digits allowed in the integer portion of a number. minIntDigits must
+   * be <= maxIntDigits. If the new value for minIntDigits exceeds the current value of
+   * maxIntDigits, then maxIntDigits will also be set to the new value
+   *
+   * @return the minimum integer digits
+   * @see java.text.NumberFormat#setMinimumIntegerDigits(int)
+   */
   int minIntDigits() default -1;
+
+  /**
+   * Sets the currency code of the currency to use when formatting this Numeric
+   * @return The currency code
+   * @see java.text.NumberFormat#setCurrency(Currency)
+   * @see java.util.Currency#getInstance(String)
+   */
   String currencyCode() default "";
+
+  /**
+   * Sets whether grouping should be used.
+   * For example, in the English locale, with grouping on, the number 1234567 might be formatted as "1,234,567".
+   * The grouping separator as well as the size of each group is locale dependent and is determined by
+   * sub-classes of NumberFormat.
+   * @return true if grouping is used; false otherwise
+   * @see java.text.NumberFormat
+   */
   boolean groupingUsed() default false;
+
+  /**
+   * Sets whether only the integer part should be parsed.
+   * E.g: if true, "345.67" -> 345
+   * @return true if only the integer part is parsed, false otherwise
+   * @see java.text.NumberFormat#isParseIntegerOnly()
+   */
   boolean parseIntegerOnly() default false;
-  RoundingMode roundingMode() default RoundingMode.HALF_UP; // TODO what is the default value for RoundingMode?
+
+  /**
+   * Sets the rounding mode to use when rounding is necessary.
+   * @return The used rounding mode
+   * @see java.text.NumberFormat#setRoundingMode(RoundingMode)
+   * @see java.math.RoundingMode
+   */
+  RoundingMode roundingMode() default RoundingMode.UNNECESSARY;
 }

--- a/src/main/java/com/docutools/jocument/annotations/Percentage.java
+++ b/src/main/java/com/docutools/jocument/annotations/Percentage.java
@@ -1,0 +1,9 @@
+package com.docutools.jocument.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Percentage {
+  int maxFractionDigits() default -1;
+}

--- a/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
+++ b/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
@@ -4,20 +4,25 @@ import com.docutools.jocument.PlaceholderData;
 import com.docutools.jocument.PlaceholderResolver;
 import com.docutools.jocument.annotations.Format;
 import com.docutools.jocument.annotations.Image;
+import com.docutools.jocument.annotations.Money;
+import com.docutools.jocument.annotations.Percentage;
 import com.docutools.jocument.impl.word.placeholders.ImagePlaceholderData;
+import org.apache.commons.beanutils.BeanUtilsBean;
+import org.apache.commons.beanutils.PropertyUtilsBean;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
+import java.text.NumberFormat;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.Temporal;
 import java.util.Collection;
+import java.util.Currency;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.apache.commons.beanutils.BeanUtilsBean;
-import org.apache.commons.beanutils.PropertyUtilsBean;
 
 /**
  * Takes a {@link java.lang.Object} of any type and resolves placeholder names with reflective access to its type.
@@ -46,13 +51,16 @@ public class ReflectionResolver implements PlaceholderResolver {
   }
 
   @Override
-  public Optional<PlaceholderData> resolve(String placeholderName) {
+  public Optional<PlaceholderData> resolve(String placeholderName, Locale locale) {
     try {
       var type = pub.getPropertyType(bean, placeholderName);
       if (type == null) {
         return Optional.empty();
       }
-      if (type.isPrimitive() || type.equals(String.class) || type.isEnum()) {
+      if(ReflectionUtils.isNumeric(type)) {
+        var numberFormat = findNumberFormat(placeholderName, locale);
+        return Optional.of(new ScalarPlaceholderData(numberFormat.format(pub.getProperty(bean, placeholderName))));
+      } else if (type.isPrimitive() || type.equals(String.class) || type.isEnum()) {
         return Optional.of(new ScalarPlaceholderData(bub.getProperty(bean, placeholderName)));
       } else if (Collection.class.isAssignableFrom(type)) {
         Collection<Object> property = (Collection<Object>) pub.getProperty(bean, placeholderName);
@@ -75,6 +83,31 @@ public class ReflectionResolver implements PlaceholderResolver {
     } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
       throw new IllegalStateException("Could not resolve placeholderName against type.", e);
     }
+  }
+
+  private NumberFormat findNumberFormat(String fieldName, Locale locale) {
+    return ReflectionUtils.findFieldAnnotation(bean.getClass(), fieldName, Percentage.class)
+            .map(percentage -> toNumberFormat(percentage, locale))
+            .or(() -> ReflectionUtils.findFieldAnnotation(bean.getClass(), fieldName, Money.class)
+                    .map(money -> toNumberFormat(money, locale)))
+            .orElseGet(() -> NumberFormat.getInstance(locale));
+  }
+
+  private static NumberFormat toNumberFormat(Percentage percentage, Locale locale) {
+    var format = NumberFormat.getPercentInstance(locale);
+    if(percentage.maxFractionDigits() > -1) {
+      format.setMaximumFractionDigits(percentage.maxFractionDigits());
+    }
+    return format;
+  }
+
+  private static NumberFormat toNumberFormat(Money money, Locale locale) {
+    var currency = !money.currencyCode().isBlank()?
+            Currency.getInstance(money.currencyCode()) :
+            Currency.getInstance(locale);
+    var format = NumberFormat.getCurrencyInstance(locale);
+    format.setCurrency(currency);
+    return format;
   }
 
   private static DateTimeFormatter toDateTimeFormatter(Format format) {

--- a/src/main/java/com/docutools/jocument/impl/ReflectionUtils.java
+++ b/src/main/java/com/docutools/jocument/impl/ReflectionUtils.java
@@ -3,8 +3,12 @@ package com.docutools.jocument.impl;
 import java.lang.annotation.Annotation;
 import java.time.temporal.Temporal;
 import java.util.Optional;
+import java.util.Set;
 
 public class ReflectionUtils {
+
+  private static final Set<Class<?>> NUMERIC_PRIMITIVES =
+          Set.of(byte.class, short.class, int.class, long.class, float.class, double.class);
 
   public static boolean isJsr310Type(Class<?> type) {
     return Temporal.class.isAssignableFrom(type);
@@ -26,6 +30,11 @@ public class ReflectionUtils {
     } catch (NoSuchFieldException e) {
       return Optional.empty();
     }
+  }
+
+  public static boolean isNumeric(Class<?> type) {
+    return type != null &&
+            (Number.class.isAssignableFrom(type) || NUMERIC_PRIMITIVES.contains(type));
   }
 
   private ReflectionUtils() {

--- a/src/test/java/com/docutools/jocument/ReflectionUtilityTests.java
+++ b/src/test/java/com/docutools/jocument/ReflectionUtilityTests.java
@@ -13,6 +13,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.util.Date;
 import java.util.Optional;
 import java.util.zip.Adler32;
 
@@ -68,4 +69,20 @@ public class ReflectionUtilityTests {
     assertThat(result.isEmpty(), is(true));
   }
 
+  @ParameterizedTest(name = "Should detect {0} as numeric type.")
+  @ValueSource(classes = {
+          byte.class, short.class, int.class, long.class, float.class, double.class,
+          Byte.class, Short.class, Integer.class, Long.class, Float.class, Double.class
+  })
+  void shouldDetectNumericTypes(Class<?> type) {
+    // Act + Assert
+    assertThat(ReflectionUtils.isNumeric(type), is(true));
+  }
+
+  @ParameterizedTest(name = "Should detect {0} as non-numeric type.")
+  @ValueSource(classes = {Object.class, String.class, Adler32.class, Date.class})
+  void shouldDetectNonNumericTypes(Class<?> type) {
+    // Act + Assert
+    assertThat(ReflectionUtils.isNumeric(type), is(false));
+  }
 }

--- a/src/test/java/com/docutools/jocument/format/NumberFormatting.java
+++ b/src/test/java/com/docutools/jocument/format/NumberFormatting.java
@@ -8,6 +8,7 @@ import com.docutools.jocument.impl.ReflectionResolver;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.math.RoundingMode;
 import java.util.Locale;
 
 import static org.hamcrest.MatcherAssert.*;
@@ -22,7 +23,14 @@ class NumberFormatting {
     private double p;
     @Money(currencyCode = "EUR")
     private double c;
-    @Numeric(maxIntDigits = 3)
+    @Numeric(maxFractionDigits = 4,
+            minFractionDigits = 2,
+            maxIntDigits = 6,
+            minIntDigits = 2,
+            currencyCode = "EUR",
+            groupingUsed = true,
+            parseIntegerOnly = false,
+            roundingMode = RoundingMode.HALF_EVEN)
     private double f;
 
     public double getD() {
@@ -36,6 +44,8 @@ class NumberFormatting {
     public double getC() {
       return c;
     }
+
+    public double getF() { return f; }
   }
 
   @Test
@@ -81,5 +91,22 @@ class NumberFormatting {
             .orElse("");
     // Assert
     assertThat(actual, equalTo("13,75\u00A0€"));
+  }
+
+  @Test
+  @DisplayName("Format numeric with the correct amount of integer places")
+  void shouldFormatNumericMaxIntDigits() {
+    // Arrange
+    var instance = new Clazz();
+    instance.f = 1123456.45675;
+    var resolver = new ReflectionResolver(instance);
+
+    // Act
+    var actual = resolver.resolve("f", Locale.GERMAN)
+            .map(PlaceholderData::toString)
+            .orElse("");
+
+    // Assert
+    assertThat(actual, equalTo("123.456,4567"));
   }
 }

--- a/src/test/java/com/docutools/jocument/format/NumberFormatting.java
+++ b/src/test/java/com/docutools/jocument/format/NumberFormatting.java
@@ -1,0 +1,85 @@
+package com.docutools.jocument.format;
+
+import com.docutools.jocument.PlaceholderData;
+import com.docutools.jocument.annotations.Money;
+import com.docutools.jocument.annotations.Numeric;
+import com.docutools.jocument.annotations.Percentage;
+import com.docutools.jocument.impl.ReflectionResolver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+@DisplayName("Format Numbers by Locale")
+class NumberFormatting {
+
+  public static class Clazz {
+    private double d;
+    @Percentage(maxFractionDigits = 2)
+    private double p;
+    @Money(currencyCode = "EUR")
+    private double c;
+    @Numeric(maxIntDigits = 3)
+    private double f;
+
+    public double getD() {
+      return d;
+    }
+
+    public double getP() {
+      return p;
+    }
+
+    public double getC() {
+      return c;
+    }
+  }
+
+  @Test
+  @DisplayName("Format floating point numbers using commas.")
+  void shouldFormatByUSStandards() {
+    // Arrange
+    var instance = new Clazz();
+    instance.d = 12345678.9;
+    var resolver = new ReflectionResolver(instance);
+    // Act
+    var actual = resolver.resolve("d", Locale.US)
+            .map(PlaceholderData::toString)
+            .orElse("");
+    // Assert
+    assertThat(actual, equalTo("12,345,678.9"));
+  }
+
+  @Test
+  @DisplayName("Format float point fields annotated with @Percentage as percentage.")
+  void shouldFormatPercentage() {
+    // Arrange
+    var instance = new Clazz();
+    instance.p = 0.555;
+    var resolver = new ReflectionResolver(instance);
+    // Act
+    var actual = resolver.resolve("p")
+            .map(PlaceholderData::toString)
+            .orElse("");
+    // Assert
+    assertThat(actual, equalTo("55,5\u00A0%"));
+  }
+
+  @Test
+  @DisplayName("Format floating point fields annoted with @Money as monetary amount.")
+  void shouldFormatMoney() {
+    // Arrange
+    var instance = new Clazz();
+    instance.c = 13.75;
+    var resolver = new ReflectionResolver(instance);
+    // Act
+    var actual = resolver.resolve("c", Locale.GERMAN)
+            .map(PlaceholderData::toString)
+            .orElse("");
+    // Assert
+    assertThat(actual, equalTo("13,75\u00A0€"));
+  }
+}

--- a/src/test/java/com/docutools/jocument/sample/SamplePlaceholderResolver.java
+++ b/src/test/java/com/docutools/jocument/sample/SamplePlaceholderResolver.java
@@ -6,6 +6,7 @@ import com.docutools.jocument.impl.IterablePlaceholderData;
 import com.docutools.jocument.impl.ScalarPlaceholderData;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 public class SamplePlaceholderResolver implements PlaceholderResolver {
@@ -15,7 +16,7 @@ public class SamplePlaceholderResolver implements PlaceholderResolver {
                   new ServicePlaceholderResolver("US Defiant"));
 
   @Override
-  public Optional<PlaceholderData> resolve(String placeholderName) {
+  public Optional<PlaceholderData> resolve(String placeholderName, Locale locale) {
     switch (placeholderName) {
       case "name":
         return Optional.of(new ScalarPlaceholderData("James T. Kirk"));

--- a/src/test/java/com/docutools/jocument/sample/ServicePlaceholderResolver.java
+++ b/src/test/java/com/docutools/jocument/sample/ServicePlaceholderResolver.java
@@ -4,6 +4,7 @@ import com.docutools.jocument.PlaceholderData;
 import com.docutools.jocument.PlaceholderResolver;
 import com.docutools.jocument.impl.ScalarPlaceholderData;
 
+import java.util.Locale;
 import java.util.Optional;
 
 public class ServicePlaceholderResolver implements PlaceholderResolver {
@@ -15,7 +16,7 @@ public class ServicePlaceholderResolver implements PlaceholderResolver {
   }
 
   @Override
-  public Optional<PlaceholderData> resolve(String placeholderName) {
+  public Optional<PlaceholderData> resolve(String placeholderName, Locale locale) {
     switch (placeholderName) {
       case "name":
         return Optional.of(new ScalarPlaceholderData(name));


### PR DESCRIPTION
To be able to specify tightly controlled numeric
strings, the `@Numeric` annotation was implemented
With this annotation, it is possible to specify the
maximum and minimum amount of digits of the integer
and fractional part, the currencyCode, whether to use
grouping, whether to only display the integer and the
rounding mode for the string representation of
annotated numbers.

Fixes #8 