### PR TITLE
Fix errors introduced during Resolver refactoring

### DIFF
--- a/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
+++ b/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
@@ -66,7 +66,9 @@ public class ReflectionResolver implements PlaceholderResolver {
         var value = pub.getProperty(bean, placeholderName);
         return Optional.of(new IterablePlaceholderData(List.of(new ReflectionResolver(value)), 1));
       }
-    } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+    } catch (NoSuchMethodException | IllegalArgumentException e) {
+      return Optional.empty();
+    } catch (IllegalAccessException | InvocationTargetException e ) {
       throw new IllegalStateException("Could not resolve placeholderName against type.", e);
     }
   }

--- a/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
+++ b/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
@@ -48,7 +48,7 @@ public class ReflectionResolver implements PlaceholderResolver {
   public Optional<PlaceholderData> resolve(String placeholderName) {
     try {
       var property = pub.getProperty(bean, placeholderName);
-      if (property instanceof Enum || property instanceof String || property.getClass().isPrimitive()) {
+      if (property instanceof Enum || property instanceof String || ReflectionUtils.isWrapperType(property.getClass())) {
         return Optional.of(new ScalarPlaceholderData(property.toString()));
       } else if (property instanceof Collection<?> collection) {
         List<PlaceholderResolver> list = collection.stream()

--- a/src/main/java/com/docutools/jocument/impl/ReflectionUtils.java
+++ b/src/main/java/com/docutools/jocument/impl/ReflectionUtils.java
@@ -3,12 +3,23 @@ package com.docutools.jocument.impl;
 import java.lang.annotation.Annotation;
 import java.time.temporal.Temporal;
 import java.util.Optional;
+import java.util.Set;
 
 public class ReflectionUtils {
 
   public static boolean isJsr310Type(Class<?> type) {
     return Temporal.class.isAssignableFrom(type);
   }
+
+  private static Set<Class<?>> WRAPPER_TYPES = Set.of(Boolean.class,
+          Character.class,
+          Byte.class,
+          Short.class,
+          Integer.class,
+          Long.class,
+          Float.class,
+          Double.class,
+          Void.class);
 
   /**
    * Gets the annotation instance on the given field in the base class.
@@ -26,6 +37,10 @@ public class ReflectionUtils {
     } catch (NoSuchFieldException e) {
       return Optional.empty();
     }
+  }
+
+  public static boolean isWrapperType(Class<?> class_) {
+    return WRAPPER_TYPES.contains(class_);
   }
 
   private ReflectionUtils() {


### PR DESCRIPTION
With #11 a few bugs were introduced in the checking of the property type.
This Pull Request should fix them.
The problems were:
* `getProperty` on unknown cell throws either `NoSuchMethodException` or `IllegalArgumentException`, those get now cached and `Optional.empty()` is returned.
* `getProperty` returns `Object`, so `.getClass().isPrimitive()` always returned false, so a new util
method `hasWrapperType` was created to check whether the object is a wrapper type (`Integer, Float,...`)