### PR TITLE
Fix formatting of unannotated `Temporal`

### DIFF
--- a/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
+++ b/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
@@ -4,7 +4,6 @@ import com.docutools.jocument.PlaceholderData;
 import com.docutools.jocument.PlaceholderResolver;
 import com.docutools.jocument.annotations.*;
 import com.docutools.jocument.impl.word.placeholders.ImagePlaceholderData;
-import org.apache.commons.beanutils.BeanUtilsBean;
 import org.apache.commons.beanutils.PropertyUtilsBean;
 
 import java.lang.annotation.Annotation;
@@ -12,14 +11,14 @@ import java.lang.reflect.InvocationTargetException;
 import java.math.RoundingMode;
 import java.nio.file.Path;
 import java.text.NumberFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.time.temporal.Temporal;
-import java.util.Collection;
-import java.util.Currency;
-import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -58,26 +57,43 @@ public class ReflectionResolver implements PlaceholderResolver {
       else if (property instanceof Enum || property instanceof String || ReflectionUtils.isWrapperType(property.getClass())) {
         return Optional.of(new ScalarPlaceholderData(property.toString()));
       } else if (property instanceof Collection<?> collection) {
-        List<PlaceholderResolver> list = collection.stream()
-                .map(ReflectionResolver::new)
-                .collect(Collectors.toList());
-        return Optional.of(new IterablePlaceholderData(list, list.size()));
-      } else if (property instanceof Temporal time && isFieldAnnotatedWith(bean.getClass(), placeholderName, Format.class)) {
-        return ReflectionUtils.findFieldAnnotation(bean.getClass(), placeholderName, Format.class)
-                .map(ReflectionResolver::toDateTimeFormatter)
-                .map(formatter -> formatter.format(time))
-                .map(ScalarPlaceholderData::new);
-      } else if (property instanceof Path path && isFieldAnnotatedWith(bean.getClass(), placeholderName, Image.class)) {
-        return Optional.of(new ImagePlaceholderData(path));
-      } else {
-        var value = pub.getProperty(bean, placeholderName);
-        return Optional.of(new IterablePlaceholderData(List.of(new ReflectionResolver(value)), 1));
-      }
+          List<PlaceholderResolver> list = collection.stream()
+                  .map(ReflectionResolver::new)
+                  .collect(Collectors.toList());
+          return Optional.of(new IterablePlaceholderData(list, list.size()));
+        } else if (property instanceof Temporal temporal) {
+          return formatTemporal(placeholderName, temporal, locale);
+        } else if (property instanceof Path path && isFieldAnnotatedWith(bean.getClass(), placeholderName, Image.class)) {
+          return Optional.of(new ImagePlaceholderData(path));
+        } else {
+          var value = pub.getProperty(bean, placeholderName);
+          return Optional.of(new IterablePlaceholderData(List.of(new ReflectionResolver(value)), 1));
+        }
     } catch (NoSuchMethodException | IllegalArgumentException e) {
       return Optional.empty();
-    } catch (IllegalAccessException | InvocationTargetException e ) {
+    } catch (IllegalAccessException | InvocationTargetException e) {
       throw new IllegalStateException("Could not resolve placeholderName against type.", e);
     }
+  }
+
+  private Optional<PlaceholderData> formatTemporal(String placeholderName, Temporal time, Locale locale) {
+    Optional<DateTimeFormatter> formatter;
+    if (isFieldAnnotatedWith(bean.getClass(), placeholderName, Format.class)) {
+      formatter = ReflectionUtils.findFieldAnnotation(bean.getClass(), placeholderName, Format.class)
+              .map(ReflectionResolver::toDateTimeFormatter);
+    } else {
+      if (time instanceof LocalDate) {
+        formatter = Optional.of(DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT));
+      } else if (time instanceof LocalTime) {
+        formatter = Optional.of(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT));
+      } else if (time instanceof LocalDateTime) {
+        formatter = Optional.of(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT));
+      } else {
+        formatter = Optional.empty();
+      }
+      formatter.map(dateTimeFormatter -> dateTimeFormatter.withLocale(locale));
+    }
+    return formatter.map(dateTimeFormatter -> new ScalarPlaceholderData(dateTimeFormatter.format(time)));
   }
 
   private NumberFormat findNumberFormat(String fieldName, Locale locale) {


### PR DESCRIPTION
Until now, unannotated `Temporal` were formatted wrongly,
since the format condition depended on the annotation
also being there.
This commit introduces correct formatting for unannotated
`Temporal`.
Since `Temporal` is only an interface, the
actual deployed formatter has to be chosen depending
on the subtype of the `Temporal` to avoid throwing
exceptions (`DateTimeFormatter` needs both date and time)

Fixes #17 

Signed-off-by: Anton Oellerer <a.oellerer@docu-tools.com>