### PR TITLE
Add logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ dependencies {
     implementation("com.google.code.gson:gson:2.8.6")
     implementation("org.apache.tika:tika-core:1.23")
 
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.13.1'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.13.1'
+
     implementation("com.github.codecitizen:jlibvips:f9df6c8")
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.0')

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation("org.apache.tika:tika-core:1.23")
 
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.13.1'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.13.1'
+    runtime group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.13.1'
 
     implementation("com.github.codecitizen:jlibvips:f9df6c8")
 

--- a/src/main/java/com/docutools/jocument/impl/DocumentImpl.java
+++ b/src/main/java/com/docutools/jocument/impl/DocumentImpl.java
@@ -3,11 +3,15 @@ package com.docutools.jocument.impl;
 import com.docutools.jocument.Document;
 import com.docutools.jocument.PlaceholderResolver;
 import com.docutools.jocument.Template;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.regex.Pattern;
 
 public abstract class DocumentImpl extends Thread implements Document {
+  private static final Logger logger = LogManager.getLogger();
 
   public static final Pattern TAG_PATTERN = Pattern.compile("\\{\\{([A-Za-z0-9[\u00c4\u00e4\u00d6\u00f6\u00dc\u00fc\u00df]-/#]+?)}}");
 
@@ -27,8 +31,11 @@ public abstract class DocumentImpl extends Thread implements Document {
   @Override
   public void run() {
     try {
+      logger.info("Starting generating document from path {} with template {} and resolver {}", path, template, resolver);
       this.path = generate();
+      logger.info("Finished generating document from path {} with template {} and resolver {}", path, template, resolver);
     } catch (IOException e) {
+      logger.error("Encountered IOException when generating document from path {} with template {} and resolver {}".formatted(path, template, resolver), e);
       throw new IllegalStateException("Got IOException when generating, probably due to template.", e);
     }
     complete = true;

--- a/src/main/java/com/docutools/jocument/impl/DocumentImpl.java
+++ b/src/main/java/com/docutools/jocument/impl/DocumentImpl.java
@@ -35,7 +35,7 @@ public abstract class DocumentImpl extends Thread implements Document {
       this.path = generate();
       logger.info("Finished generating document from path {} with template {} and resolver {}", path, template, resolver);
     } catch (IOException e) {
-      logger.error("Encountered IOException when generating document from path {} with template {} and resolver {}".formatted(path, template, resolver), e);
+      logger.error("Encountered IOException when generating document from path %s with template %s and resolver %s".formatted(path, template, resolver), e);
       throw new IllegalStateException("Got IOException when generating, probably due to template.", e);
     }
     complete = true;

--- a/src/main/java/com/docutools/jocument/impl/DocumentImpl.java
+++ b/src/main/java/com/docutools/jocument/impl/DocumentImpl.java
@@ -43,6 +43,7 @@ public abstract class DocumentImpl extends Thread implements Document {
 
   @Override
   public void blockUntilCompletion(long millis) throws InterruptedException {
+    logger.info("Waiting for completion for {} milliseconds", millis);
     super.join(millis);
   }
 

--- a/src/main/java/com/docutools/jocument/impl/JsonResolver.java
+++ b/src/main/java/com/docutools/jocument/impl/JsonResolver.java
@@ -45,6 +45,7 @@ public class JsonResolver implements PlaceholderResolver {
      * @throws JsonParseException if the specified text is not valid JSON
      */
     public JsonResolver(String json) {
+        logger.info("Creating JSON resolver from {}", json);
         this.jsonElement = JsonParser.parseString(json);
     }
 
@@ -56,6 +57,7 @@ public class JsonResolver implements PlaceholderResolver {
      * @throws JsonParseException if the downloaded text is not valid JSON
      */
     public JsonResolver(URL url) throws IOException {
+        logger.info("Trying to create JSON resolver from {}", url);
         try (InputStream stream = url.openStream()) {
             JsonReader reader = new JsonReader(new BufferedReader(new InputStreamReader(stream)));
             this.jsonElement = JsonParser.parseReader(reader);
@@ -75,6 +77,7 @@ public class JsonResolver implements PlaceholderResolver {
         } else if (jsonElement.isJsonArray()) {
             return fromArray(jsonElement.getAsJsonArray());
         }
+        logger.debug("Did not manage to resolver placeholder {}", placeholderName);
         return Optional.empty();
     }
 
@@ -94,7 +97,7 @@ public class JsonResolver implements PlaceholderResolver {
             return Optional.of(new IterablePlaceholderData(List.of(new JsonResolver(json)), 1));
         }
 
-        logger.warn("Failed to resolve placeholder {} in JSON Object {} to placeholder data", placeholderName, jsonObject);
+        logger.warn("Failed to resolve placeholder {} as JSON Object {} to placeholder data", placeholderName, jsonObject);
         return Optional.empty();
     }
 

--- a/src/main/java/com/docutools/jocument/impl/JsonResolver.java
+++ b/src/main/java/com/docutools/jocument/impl/JsonResolver.java
@@ -125,7 +125,7 @@ public class JsonResolver implements PlaceholderResolver {
             IOUtils.copy(stream, tmp.toFile());
             return Optional.of(tmp);
         } catch (IOException e) {
-            logger.warn("Encountered IOException when trying to resolve URL {}".formatted(url), e);
+            logger.warn("Encountered IOException when trying to resolve URL %s".formatted(url), e);
             return Optional.empty();
         }
     }

--- a/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
+++ b/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
@@ -77,7 +77,7 @@ public class ReflectionResolver implements PlaceholderResolver {
       logger.debug("Did not find placeholder {}", placeholderName);
       return Optional.empty();
     } catch (IllegalAccessException | InvocationTargetException e) {
-      logger.error("Could not resolve placeholder {}".formatted(placeholderName), e);
+      logger.error("Could not resolve placeholder %s".formatted(placeholderName), e);
       throw new IllegalStateException("Could not resolve placeholderName against type.", e);
     }
   }

--- a/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
+++ b/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
@@ -44,7 +44,8 @@ public class ReflectionResolver implements PlaceholderResolver {
     try {
       return clazz.getDeclaredField(fieldName)
               .getDeclaredAnnotation(annotation) != null;
-    } catch (Exception ignored) {
+    } catch (Exception e) {
+      logger.debug("Class %s not annotated with %s".formatted(clazz, fieldName), e);
       return false;
     }
   }
@@ -110,7 +111,10 @@ public class ReflectionResolver implements PlaceholderResolver {
                     .map(money -> toNumberFormat(money, locale)))
             .or(() -> ReflectionUtils.findFieldAnnotation(bean.getClass(), fieldName, Numeric.class)
                     .map(numeric -> toNumberFormat(numeric, locale)))
-            .orElseGet(() -> NumberFormat.getInstance(locale));
+            .orElseGet(() -> {
+              logger.info("Did not find formatting directive for {}, formatting according to locale {}", fieldName, locale);
+              return NumberFormat.getInstance(locale);
+            });
   }
 
   private static NumberFormat toNumberFormat(Percentage percentage, Locale locale) {

--- a/src/main/java/com/docutools/jocument/impl/ReflectionUtils.java
+++ b/src/main/java/com/docutools/jocument/impl/ReflectionUtils.java
@@ -1,11 +1,15 @@
 package com.docutools.jocument.impl;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.lang.annotation.Annotation;
 import java.time.temporal.Temporal;
 import java.util.Optional;
 import java.util.Set;
 
 public class ReflectionUtils {
+  private static final Logger logger = LogManager.getLogger();
 
   public static boolean isJsr310Type(Class<?> type) {
     return Temporal.class.isAssignableFrom(type);
@@ -31,10 +35,12 @@ public class ReflectionUtils {
    * @return the annotated instance on the field
    */
   public static <A extends Annotation> Optional<A> findFieldAnnotation(Class<?> baseClass, String fieldName, Class<A> annotationType) {
+    logger.debug("Searching for annotation {} in class {}", fieldName, baseClass);
     try {
       return Optional.ofNullable(baseClass.getDeclaredField(fieldName)
               .getDeclaredAnnotation(annotationType));
     } catch (NoSuchFieldException e) {
+      logger.info("Did not find annotation {} in class {}", fieldName, baseClass);
       return Optional.empty();
     }
   }

--- a/src/main/java/com/docutools/jocument/impl/TemplateImpl.java
+++ b/src/main/java/com/docutools/jocument/impl/TemplateImpl.java
@@ -5,6 +5,8 @@ import com.docutools.jocument.MimeType;
 import com.docutools.jocument.PlaceholderResolver;
 import com.docutools.jocument.Template;
 import com.docutools.jocument.impl.word.WordDocumentImpl;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -12,6 +14,7 @@ import java.net.URL;
 import java.util.Locale;
 
 public class TemplateImpl implements Template {
+    private static final Logger logger = LogManager.getLogger();
 
   private final URL url;
   private final MimeType mimeType;
@@ -35,9 +38,11 @@ public class TemplateImpl implements Template {
 
   @Override
   public Document startGeneration(PlaceholderResolver resolver) {
-    var document = new WordDocumentImpl(this, resolver);
-    document.start();
-    return document;
+      logger.info("Starting generating from template {} with resolver {}", this, resolver);
+      var document = new WordDocumentImpl(this, resolver);
+      document.start();
+      logger.info("Finished generating from template {} with resolver {}", this, resolver);
+      return document;
   }
 
   @Override

--- a/src/main/java/com/docutools/jocument/impl/word/CustomWordPlaceholderData.java
+++ b/src/main/java/com/docutools/jocument/impl/word/CustomWordPlaceholderData.java
@@ -2,10 +2,13 @@ package com.docutools.jocument.impl.word;
 
 import com.docutools.jocument.PlaceholderData;
 import com.docutools.jocument.PlaceholderType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.poi.xwpf.usermodel.IBodyElement;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 
 public abstract class CustomWordPlaceholderData implements PlaceholderData {
+  private static final Logger logger = LogManager.getLogger();
 
   @Override
   public PlaceholderType getType() {
@@ -15,6 +18,7 @@ public abstract class CustomWordPlaceholderData implements PlaceholderData {
   @Override
   public void transform(Object placeholder) {
     if (!(placeholder instanceof IBodyElement)) {
+      logger.error("{} is not an instance of IBodyElement", placeholder);
       throw new IllegalArgumentException("Only IBodyElements accepted.");
     }
 

--- a/src/main/java/com/docutools/jocument/impl/word/WordDocumentImpl.java
+++ b/src/main/java/com/docutools/jocument/impl/word/WordDocumentImpl.java
@@ -3,6 +3,8 @@ package com.docutools.jocument.impl.word;
 import com.docutools.jocument.PlaceholderResolver;
 import com.docutools.jocument.Template;
 import com.docutools.jocument.impl.DocumentImpl;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.poi.util.LocaleUtil;
 import org.apache.poi.xwpf.usermodel.IBodyElement;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
@@ -16,6 +18,7 @@ import java.util.List;
 import java.util.Locale;
 
 public class WordDocumentImpl extends DocumentImpl {
+  private static final Logger logger = LogManager.getLogger();
 
   public WordDocumentImpl(Template template, PlaceholderResolver resolver) {
     super(template, resolver);
@@ -23,6 +26,7 @@ public class WordDocumentImpl extends DocumentImpl {
 
   @Override
   protected Path generate() throws IOException {
+    logger.info("Starting generation");
     Path file = Files.createTempFile("document", ".docx");
     try (XWPFDocument document = new XWPFDocument(template.openStream())) {
       LocaleUtil.setUserLocale(WordUtilities.detectMostCommonLocale(document).orElse(Locale.getDefault()));
@@ -35,6 +39,7 @@ public class WordDocumentImpl extends DocumentImpl {
         document.write(os);
       }
     }
+    logger.info("Finished generation");
     return file;
   }
 

--- a/src/main/java/com/docutools/jocument/impl/word/WordDocumentImpl.java
+++ b/src/main/java/com/docutools/jocument/impl/word/WordDocumentImpl.java
@@ -29,13 +29,18 @@ public class WordDocumentImpl extends DocumentImpl {
     logger.info("Starting generation");
     Path file = Files.createTempFile("document", ".docx");
     try (XWPFDocument document = new XWPFDocument(template.openStream())) {
-      LocaleUtil.setUserLocale(WordUtilities.detectMostCommonLocale(document).orElse(Locale.getDefault()));
+      var locale = WordUtilities.detectMostCommonLocale(document).orElse(Locale.getDefault());
+      LocaleUtil.setUserLocale(locale);
+      logger.info("Set user locale to {}", locale);
+
       List<IBodyElement> bodyElements = new ArrayList<>(document.getBodyElements().size());
       bodyElements.addAll(document.getBodyElements());
 
+      logger.debug("Retrieved all body elements, starting WordGenerator");
       WordGenerator.apply(resolver, bodyElements);
 
       try (OutputStream os = Files.newOutputStream(file)) {
+        logger.info("Writing document to {}", os);
         document.write(os);
       }
     }

--- a/src/main/java/com/docutools/jocument/impl/word/WordGenerator.java
+++ b/src/main/java/com/docutools/jocument/impl/word/WordGenerator.java
@@ -4,6 +4,8 @@ import com.docutools.jocument.PlaceholderData;
 import com.docutools.jocument.PlaceholderResolver;
 import com.docutools.jocument.PlaceholderType;
 import com.docutools.jocument.impl.ParsingUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.poi.util.LocaleUtil;
 import org.apache.poi.xwpf.usermodel.*;
 
@@ -15,6 +17,7 @@ import java.util.stream.Collectors;
 import static com.docutools.jocument.impl.DocumentImpl.TAG_PATTERN;
 
 class WordGenerator {
+  private static final Logger logger = LogManager.getLogger();
 
   private final PlaceholderResolver resolver;
   private final List<IBodyElement> elements;
@@ -25,6 +28,7 @@ class WordGenerator {
   }
 
   static void apply(PlaceholderResolver resolver, List<IBodyElement> elements) {
+    logger.debug("Generating by applying resolver {} to elements {}", resolver, elements);
     new WordGenerator(resolver, elements).generate();
   }
 
@@ -52,6 +56,7 @@ class WordGenerator {
     } else if (element instanceof XWPFTable xwpfTable) {
       transform(xwpfTable);
     }
+    logger.info("Failed to transform element {}", element);
   }
 
   private void transform(XWPFTable table) {

--- a/src/main/java/com/docutools/jocument/impl/word/WordGenerator.java
+++ b/src/main/java/com/docutools/jocument/impl/word/WordGenerator.java
@@ -28,11 +28,11 @@ class WordGenerator {
   }
 
   static void apply(PlaceholderResolver resolver, List<IBodyElement> elements) {
-    logger.debug("Generating by applying resolver {} to elements {}", resolver, elements);
     new WordGenerator(resolver, elements).generate();
   }
 
   private void generate() {
+    logger.debug("Starting generation by applying resolver {} to elements {}", resolver, elements);
     for (int i = 0; i < elements.size(); i++) {
       var element = elements.get(i);
 
@@ -43,9 +43,11 @@ class WordGenerator {
       var remaining = elements.subList(i + 1, elements.size());
       transform(element, remaining);
     }
+    logger.debug("Finished generation of elements {} by resolver {}", elements, resolver);
   }
 
   private void transform(IBodyElement element, List<IBodyElement> remaining) {
+    logger.debug("Trying to transform element {}", element);
     if (isLoopStart(element)) {
       unrollLoop((XWPFParagraph) element, remaining);
     } else if (isCustomPlaceholder(element)) {
@@ -67,6 +69,7 @@ class WordGenerator {
             .map(XWPFTableCell::getParagraphs)
             .flatMap(List::stream)
             .forEach(this::transform);
+    logger.debug("Transformed table {}", table);
   }
 
   private void transform(XWPFParagraph paragraph) {
@@ -78,10 +81,12 @@ class WordGenerator {
                     .matcher(WordUtilities.toString(paragraph))
                     .replaceAll(matchResult -> fillPlaceholder(matchResult, locale))
     );
+    logger.debug("Transformed paragraph {}", paragraph);
   }
 
   private void unrollLoop(XWPFParagraph start, List<IBodyElement> remaining) {
     var placeholderName = extractPlaceholderName(start);
+    logger.debug("Unrolling loop of {}", placeholderName);
     var placeholderData = resolver.resolve(placeholderName)
             .filter(p -> p.getType() == PlaceholderType.SET)
             .orElseThrow();
@@ -91,6 +96,7 @@ class WordGenerator {
             apply(itemResolver, WordUtilities.copyBefore(content, start)));
 
     removeLoop(start, content, remaining);
+    logger.debug("Unrolled loop of {}", placeholderName);
   }
 
   private void removeLoop(IBodyElement start, List<IBodyElement> content, List<IBodyElement> remaining) {
@@ -101,6 +107,7 @@ class WordGenerator {
 
   private List<IBodyElement> getLoopBody(String placeholderName, List<IBodyElement> remaining) {
     var endLoopMarker = String.format("{{/%s}}", placeholderName);
+    logger.debug("Getting loop body from {} to {}", placeholderName, endLoopMarker);
     return remaining.stream()
             //Could be written nice with `takeUntil(element -> (element instanceof XP xp && eLM.equals(WU.toString(xp)))
             .takeWhile(element -> !(element instanceof XWPFParagraph xwpfParagraph &&
@@ -135,6 +142,7 @@ class WordGenerator {
   private String fillPlaceholder(MatchResult result, Locale locale) {
     String placeholder = result.group();
     String placeholderName = ParsingUtils.stripBrackets(placeholder);
+    logger.debug("Resolving placeholder {}", placeholderName);
     return resolver.resolve(placeholderName, locale)
             .map(PlaceholderData::toString)
             .orElse("-");

--- a/src/main/java/com/docutools/jocument/impl/word/WordImageUtils.java
+++ b/src/main/java/com/docutools/jocument/impl/word/WordImageUtils.java
@@ -1,12 +1,7 @@
 package com.docutools.jocument.impl.word;
 
-import java.awt.Dimension;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.util.Map;
-import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.util.Units;
 import org.apache.poi.xwpf.usermodel.Document;
@@ -15,7 +10,16 @@ import org.apache.poi.xwpf.usermodel.XWPFPicture;
 import org.jlibvips.VipsImage;
 import org.jlibvips.jna.VipsBindingsSingleton;
 
+import java.awt.*;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+import java.util.Optional;
+
 public class WordImageUtils {
+  private static final Logger logger = LogManager.getLogger();
 
   public static final Map<String, Integer> XWPF_CONTENT_TYPE_MAPPING =
           Map.of(
@@ -59,6 +63,7 @@ public class WordImageUtils {
       return paragraph.createRun()
               .addPicture(in, contentType, path.getFileName().toString(), dim.width, dim.height);
     } catch (InvalidFormatException | IOException e) {
+      logger.error("Could not insert image from given Path %s.".formatted(path), e);
       throw new IllegalArgumentException("Could not insert image form given Path.", e);
     }
   }
@@ -69,6 +74,7 @@ public class WordImageUtils {
       image = VipsImage.fromFile(path);
       return Optional.of(new Dimension(image.getWidth(), image.getHeight()));
     } catch (Exception e) {
+      logger.warn("Failed to get dimensions of image from path %s".formatted(path), e);
       return Optional.empty();
     } finally {
       if (image != null) {
@@ -110,7 +116,8 @@ public class WordImageUtils {
     try {
       return Optional.ofNullable(Files.probeContentType(path))
               .filter(contentType -> !contentType.isBlank());
-    } catch (Exception ignored) {
+    } catch (Exception e) {
+      logger.warn("Failed to probe content type of path %s".formatted(path), e);
       return Optional.empty();
     }
   }

--- a/src/main/java/com/docutools/jocument/impl/word/WordUtilities.java
+++ b/src/main/java/com/docutools/jocument/impl/word/WordUtilities.java
@@ -1,5 +1,7 @@
 package com.docutools.jocument.impl.word;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.poi.xwpf.usermodel.*;
 import org.apache.xmlbeans.XmlCursor;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.*;
@@ -11,6 +13,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 public class WordUtilities {
+  private static final Logger logger = LogManager.getLogger();
 
   private WordUtilities() {
   }
@@ -67,6 +70,7 @@ public class WordUtilities {
     } else if (element instanceof XWPFTable xwpfTable) {
       return OptionalInt.of(document.getPosOfTable(xwpfTable));
     }
+    logger.warn("Failed to find position of element {}", element);
     return OptionalInt.empty();
   }
 
@@ -99,7 +103,7 @@ public class WordUtilities {
     if (element instanceof XWPFParagraph xwpfParagraph) {
       return copyParagraphTo(xwpfParagraph, destinationCursor);
     }
-
+    logger.error("Failed to copy {} before {}", element, destination);
     throw new IllegalArgumentException("Can only copy XWPFParagraph or XWPFTable instances.");
   }
 
@@ -125,6 +129,7 @@ public class WordUtilities {
     } else if (element instanceof XWPFTable xwpfTable) {
       return Optional.of((xwpfTable).getCTTbl().newCursor());
     } else {
+      logger.warn("Failed to open cursor to element {}", element);
       return Optional.empty();
     }
   }
@@ -198,6 +203,7 @@ public class WordUtilities {
     try {
       return locale.getISO3Language() != null && locale.getISO3Country() != null;
     } catch (MissingResourceException e) {
+      logger.warn("Encountered missing resource exception when trying to verify locale {}".formatted(locale), e);
       return false;
     }
   }
@@ -221,6 +227,7 @@ public class WordUtilities {
     if (rawText != null && !rawText.isBlank()) {
       return Optional.of(rawText);
     }
+    logger.info("Failed to get text from paragraph {}", paragraph);
     return Optional.empty();
   }
 

--- a/src/main/java/com/docutools/jocument/impl/word/WordUtilities.java
+++ b/src/main/java/com/docutools/jocument/impl/word/WordUtilities.java
@@ -203,7 +203,7 @@ public class WordUtilities {
     try {
       return locale.getISO3Language() != null && locale.getISO3Country() != null;
     } catch (MissingResourceException e) {
-      logger.warn("Encountered missing resource exception when trying to verify locale {}".formatted(locale), e);
+      logger.warn("Encountered missing resource exception when trying to verify locale %s".formatted(locale), e);
       return false;
     }
   }

--- a/src/main/java/com/docutools/jocument/impl/word/WordUtilities.java
+++ b/src/main/java/com/docutools/jocument/impl/word/WordUtilities.java
@@ -113,6 +113,7 @@ public class WordUtilities {
    * @param element the element to be removed
    */
   public static void removeIfExists(IBodyElement element) {
+    logger.debug("Removing element {}", element);
     findPos(element)
             .ifPresent(element.getBody().getXWPFDocument()::removeBodyElement);
   }
@@ -125,8 +126,10 @@ public class WordUtilities {
    */
   public static Optional<XmlCursor> openCursor(IBodyElement element) {
     if (element instanceof XWPFParagraph xwpfParagraph) {
+      logger.debug("Opening cursor to paragraph {}", xwpfParagraph);
       return Optional.of((xwpfParagraph).getCTP().newCursor());
     } else if (element instanceof XWPFTable xwpfTable) {
+      logger.debug("Opening cursor to table {}", xwpfTable);
       return Optional.of((xwpfTable).getCTTbl().newCursor());
     } else {
       logger.warn("Failed to open cursor to element {}", element);
@@ -209,6 +212,7 @@ public class WordUtilities {
   }
 
   private static XWPFTable copyTableTo(XWPFTable sourceTable, XmlCursor cursor) {
+    logger.debug("Copying table {} before {}", sourceTable, cursor);
     var document = sourceTable.getBody().getXWPFDocument();
     XWPFTable table = document.insertNewTbl(cursor);
     cloneTable(sourceTable, table);
@@ -216,6 +220,7 @@ public class WordUtilities {
   }
 
   private static XWPFParagraph copyParagraphTo(XWPFParagraph sourceParagraph, XmlCursor cursor) {
+    logger.debug("Copying paragraph {} before {}", sourceParagraph, cursor);
     var document = sourceParagraph.getDocument();
     XWPFParagraph paragraph = document.insertNewParagraph(cursor);
     cloneParagraph(sourceParagraph, paragraph);
@@ -238,6 +243,7 @@ public class WordUtilities {
   }
 
   private static void cloneTable(XWPFTable original, XWPFTable clone) {
+    logger.debug("Cloning table {} to table {}", original, clone);
     CTTbl tbl = clone.getCTTbl();
     tbl.setTblGrid(original.getCTTbl().getTblGrid());
     CTTblPr tblPr = tbl.getTblPr();
@@ -276,6 +282,7 @@ public class WordUtilities {
   }
 
   private static void cloneParagraph(XWPFParagraph original, XWPFParagraph clone) {
+    logger.debug("Cloning table {} to table {}", original, clone);
     CTPPr ppr = clone.getCTP().isSetPPr()
             ? clone.getCTP().getPPr() : clone.getCTP().addNewPPr();
     ppr.set(original.getCTP().getPPr());
@@ -286,6 +293,7 @@ public class WordUtilities {
   }
 
   private static void cloneRun(XWPFRun original, XWPFRun clone) {
+    logger.debug("Cloning run {} to run {}", original, clone);
     CTRPr rpr = clone.getCTR().isSetRPr() ? clone.getCTR().getRPr() : clone.getCTR().addNewRPr();
     rpr.set(original.getCTR().getRPr());
     String text = original.getText(0);

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="WARN">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Since program flow and minor errors are handled, in a big
part, with `Optional`, developers and users of the library
never really know what was going on in it, and had no way
to find probable causes of errors after they happened.

This commit introduces logging into the `jocument` library.
It uses the `log4j2` library (see more in the corresponding
issue #19).
Log statements were inserted into the program following my
verdict, since I do not really know of a good logging policy
(and did not find one).
Due to steering the program flow with optionals, many
execution branches which seem fatal are only logged with
`INFO` or `DEBUG` level since they actually occur pretty
often and are not really critical (see also in issue #19).

Signed-off-by: Anton Oellerer <a.oellerer@docu-tools.com>