### PR TITLE
Add function detecting document locale

### DIFF
--- a/src/main/java/com/docutools/jocument/impl/word/WordDocumentImpl.java
+++ b/src/main/java/com/docutools/jocument/impl/word/WordDocumentImpl.java
@@ -25,7 +25,7 @@ public class WordDocumentImpl extends DocumentImpl {
   protected Path generate() throws IOException {
     Path file = Files.createTempFile("document", ".docx");
     try (XWPFDocument document = new XWPFDocument(template.openStream())) {
-      LocaleUtil.setUserLocale(WordUtilities.detectMostCommonLocale(document).orElse(Locale.getDefault()));
+      LocaleUtil.setUserLocale(WordUtilities.getDocumentLanguage(document).orElse(Locale.getDefault()));
       List<IBodyElement> bodyElements = new ArrayList<>(document.getBodyElements().size());
       bodyElements.addAll(document.getBodyElements());
 

--- a/src/main/java/com/docutools/jocument/impl/word/WordUtilities.java
+++ b/src/main/java/com/docutools/jocument/impl/word/WordUtilities.java
@@ -299,4 +299,9 @@ public class WordUtilities {
             .max(Map.Entry.comparingByValue())
             .map(Map.Entry::getKey);
   }
+
+  public static Optional<Locale> getDocumentLanguage(XWPFDocument document) {
+    var documentLanguage = document.getProperties().getCoreProperties().getUnderlyingProperties().getLanguageProperty();
+    return documentLanguage.map(Locale::forLanguageTag).or(() -> detectMostCommonLocale(document));
+  }
 }


### PR DESCRIPTION
During development, it was discovered that, contrary to
previous believe, there is a document locale (In the core
document properties) which are not accessible through the
offered interface but need to be retrieved from the
underlying properties.

Signed-off-by: Anton Oellerer <a.oellerer@docu-tools.com>