### PR TITLE
Fix setting of excel document locale

### DIFF
--- a/src/main/java/com/docutools/jocument/impl/excel/implementations/ExcelDocumentImpl.java
+++ b/src/main/java/com/docutools/jocument/impl/excel/implementations/ExcelDocumentImpl.java
@@ -4,13 +4,16 @@ import com.docutools.jocument.PlaceholderResolver;
 import com.docutools.jocument.Template;
 import com.docutools.jocument.impl.DocumentImpl;
 import com.docutools.jocument.impl.excel.interfaces.ExcelWriter;
+import com.docutools.jocument.impl.excel.util.ExcelUtils;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.util.LocaleUtil;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Iterator;
+import java.util.Locale;
 
 
 /**
@@ -44,6 +47,8 @@ public class ExcelDocumentImpl extends DocumentImpl {
         Path file = Files.createTempFile("document", ".xlsx");
         ExcelWriter excelWriter = new SXSSFWriter(file);
         try (XSSFWorkbook workbook = new XSSFWorkbook(template.openStream())) {
+            var locale = ExcelUtils.getWorkbookLanguage(workbook).orElse(Locale.getDefault());
+            LocaleUtil.setUserLocale(locale);
             for (Iterator<Sheet> it = workbook.sheetIterator(); it.hasNext(); ) {
                 Sheet sheet = it.next();
                 excelWriter.newSheet(sheet);

--- a/src/main/java/com/docutools/jocument/impl/excel/util/ExcelUtils.java
+++ b/src/main/java/com/docutools/jocument/impl/excel/util/ExcelUtils.java
@@ -5,8 +5,11 @@ import com.docutools.jocument.impl.ParsingUtils;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import java.util.Iterator;
+import java.util.Locale;
+import java.util.Optional;
 
 public class ExcelUtils {
     public static String getPlaceholder(Cell cell) {
@@ -69,5 +72,10 @@ public class ExcelUtils {
             isSimpleRow &= isSimpleCell(cell);
         }
         return isSimpleRow;
+    }
+
+    public static Optional<Locale> getWorkbookLanguage(XSSFWorkbook workbook) {
+        var workbookLanguage = workbook.getProperties().getCoreProperties().getUnderlyingProperties().getLanguageProperty();
+        return workbookLanguage.map(Locale::forLanguageTag);
     }
 }


### PR DESCRIPTION
This commit fixes the problem that the locale was not set
when generating excel documents.
It does this by introducing a helper method in ExcelUtils
which detects the document locale from the undocumented
settings.
This locale is then used for setting the per-thread user
locale

Signed-off-by: Anton Oellerer <a.oellerer@docu-tools.com>